### PR TITLE
chore: Workaround RxSwift build failure

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Graphiti",
-        "repositoryURL": "https://github.com/GraphQLSwift/Graphiti.git",
-        "state": {
-          "branch": null,
-          "revision": "c9bc9d1cc9e62e71a824dc178630bfa8b8a6e2a4",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "GraphQL",
-        "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
-        "state": {
-          "branch": null,
-          "revision": "283cc4de56b994a00b2724328221b7a1bc846ddc",
-          "version": "2.2.1"
-        }
-      },
-      {
-        "package": "GraphQLRxSwift",
-        "repositoryURL": "https://github.com/GraphQLSwift/GraphQLRxSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "c7ec6595f92ef5d77c06852e4acc4cd46a753622",
-          "version": "0.0.4"
-        }
-      },
-      {
-        "package": "RxSwift",
-        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "b4307ba0b6425c0ba4178e138799946c3da594f8",
-          "version": "6.5.0"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections",
-        "state": {
-          "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "154f1d32366449dcccf6375a173adf4ed2a74429",
-          "version": "2.38.0"
-        }
+  "pins" : [
+    {
+      "identity" : "graphiti",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GraphQLSwift/Graphiti.git",
+      "state" : {
+        "revision" : "c9bc9d1cc9e62e71a824dc178630bfa8b8a6e2a4",
+        "version" : "1.0.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "graphql",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GraphQLSwift/GraphQL.git",
+      "state" : {
+        "revision" : "283cc4de56b994a00b2724328221b7a1bc846ddc",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "graphqlrxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PassiveLogic/GraphQLRxSwift.git",
+      "state" : {
+        "revision" : "ccf9c067d86cba9e68642b2e5bdeb7236612c232",
+        "version" : "0.0.5-pl.1"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PassiveLogic/RxSwift.git",
+      "state" : {
+        "revision" : "b5a0ba4d488ded8813cde51c7d49d7ad6cb56372",
+        "version" : "6.8.1-pl.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "154f1d32366449dcccf6375a173adf4ed2a74429",
+        "version" : "2.38.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -13,8 +13,14 @@ let package = Package(
     dependencies: [
         .package(name: "Graphiti", url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
         .package(name: "GraphQL", url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.2.1"),
-        .package(name: "GraphQLRxSwift", url: "https://github.com/GraphQLSwift/GraphQLRxSwift.git", from: "0.0.4"),
-        .package(name: "RxSwift", url: "https://github.com/ReactiveX/RxSwift.git", from: "6.1.0"),
+        // TODO: Move back over to mainline GraphQLRxSwift once one of the following issues are resolved
+        // https://github.com/swiftlang/swift-corelibs-foundation/issues/5108
+        // https://github.com/ReactiveX/RxSwift/issues/2621
+        .package(url: "https://github.com/PassiveLogic/GraphQLRxSwift.git", exact: "0.0.5-pl.1"),
+        // TODO: Move back over to mainline RxSwift once one of the following issues are resolved
+        // https://github.com/swiftlang/swift-corelibs-foundation/issues/5108
+        // https://github.com/ReactiveX/RxSwift/issues/2621
+        .package(url: "https://github.com/PassiveLogic/RxSwift.git", exact: "6.8.1-pl.1"),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.33.0")
     ],
     targets: [


### PR DESCRIPTION
Adopts a custom tag for RxSwift that contains a workaround that is needed when building RxSwift on Linux against newer Swift toolchains.